### PR TITLE
Add support for netstandard2.0

### DIFF
--- a/Project/SharpLibWin32.csproj
+++ b/Project/SharpLibWin32.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net20;netstandard2.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/Project/SharpLibWin32.csproj
+++ b/Project/SharpLibWin32.csproj
@@ -1,79 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AD32FD5D-33D4-4393-86E5-E1FCD25E4800}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>SharpLib</RootNamespace>
-    <AssemblyName>SharpLibWin32</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Win32\Win32DeviceManagement.cs" />
-    <Compile Include="Win32\Win32Fsctls.cs" />
-    <Compile Include="Win32\Win32Ioctls.cs" />
-    <Compile Include="Win32\Win32SendMessage.cs" />
-    <Compile Include="Win32\Win32SystemCommands.cs" />
-    <Compile Include="Win32\Win32WindowMessages.cs" />
-    <Compile Include="Win32\Win32AppCommand.cs" />
-    <Compile Include="Win32\Win32CreateFile.cs" />
-    <Compile Include="Win32\Win32Hid.cs" />
-    <Compile Include="Win32\Win32RawInput.cs" />
-    <Compile Include="Win32\Windef.cs" />
-    <Compile Include="Win32\Winuser.cs" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/Publish/SharpLibWin32.nuspec
+++ b/Publish/SharpLibWin32.nuspec
@@ -76,6 +76,7 @@ First contribution.</releaseNotes>
         <tags>Win32 API Invoke PInvoke Platform Interop</tags>
     </metadata>
     <files>
+        <file src="..\Project\bin\Release\net20\SharpLibWin32.dll" target="lib\net20\SharpLibWin32.dll" />
         <file src="..\Project\bin\Release\netstandard2.0\SharpLibWin32.dll" target="lib\netstandard2.0\SharpLibWin32.dll" />
     </files>
 </package>

--- a/Publish/SharpLibWin32.nuspec
+++ b/Publish/SharpLibWin32.nuspec
@@ -76,6 +76,6 @@ First contribution.</releaseNotes>
         <tags>Win32 API Invoke PInvoke Platform Interop</tags>
     </metadata>
     <files>
-        <file src="..\Project\bin\Release\SharpLibWin32.dll" target="lib\net20\SharpLibWin32.dll" />
+        <file src="..\Project\bin\Release\netstandard2.0\SharpLibWin32.dll" target="lib\netstandard2.0\SharpLibWin32.dll" />
     </files>
 </package>


### PR DESCRIPTION
see #3 

Dropping support for `net20` in favor of `netstandard2.0` could look like this. Note that this is a breaking change because projects not supporting netstandard2.0 (e.g. net20) wouldn't be able to consume this package any longer. It would be possible to create a NuGet package that supports both net20 and netstandard2.0 but I think it's a bit harder to set up.